### PR TITLE
Fixed memleaks

### DIFF
--- a/src/compress.c
+++ b/src/compress.c
@@ -66,6 +66,8 @@ elzma_compress_free(elzma_compress_handle * hand)
                             (ISzAlloc *) &((*hand)->allocStruct),
                             (ISzAlloc *) &((*hand)->allocStruct));
         }
+
+	free(*hand);	
         
     }
     *hand = NULL;

--- a/test/easylzma_test.c
+++ b/test/easylzma_test.c
@@ -161,6 +161,8 @@ static int roundTripTest(elzma_file_format format)
         free(decompressed);
         return 1;
     }
+     
+    free(decompressed);
     
     return ELZMA_E_OK;
 }

--- a/test/simple.c
+++ b/test/simple.c
@@ -102,7 +102,9 @@ simpleCompress(elzma_file_format format, const unsigned char * inData,
         *outData = ds.outData;
         *outLen = ds.outLen;
     }
-
+    
+    elzma_compress_free(&hand);
+     	
     return rc;
 }
 
@@ -136,6 +138,8 @@ simpleDecompress(elzma_file_format format, const unsigned char * inData,
         *outData = ds.outData;
         *outLen = ds.outLen;
     }
+
+    elzma_decompress_free(&hand);
 
     return rc;
 }


### PR DESCRIPTION
These commits fix four different memory leaks found in easylzma, including one in the compress.c library code.
