### PR TITLE
Fix memory leaks.

### DIFF
--- a/src/compress.c
+++ b/src/compress.c
@@ -66,7 +66,7 @@ elzma_compress_free(elzma_compress_handle * hand)
                             (ISzAlloc *) &((*hand)->allocStruct),
                             (ISzAlloc *) &((*hand)->allocStruct));
         }
-        
+        free(*hand);
     }
     *hand = NULL;
 }

--- a/test/easylzma_test.c
+++ b/test/easylzma_test.c
@@ -153,16 +153,20 @@ static int roundTripTest(elzma_file_format format)
 
     free(compressed);
 
-    if (rc != ELZMA_E_OK) return rc;
-    
-    if (sz != strlen(sampleData) ||
-        0 != memcmp(decompressed, sampleData, sz))
-    {
-        free(decompressed);
-        return 1;
+    if (rc != ELZMA_E_OK) {
+        if (sz != strlen(sampleData) ||
+            0 != memcmp(decompressed, sampleData, sz))
+        {
+            rc = 1;
+        } else {
+            rc = ELZMA_E_OK;
+        }
     }
-    
-    return ELZMA_E_OK;
+
+    if (decompressed != NULL) {
+        free(decompressed);
+    }
+    return rc;
 }
 
 /* "correct" lzip generated from the lzip program */

--- a/test/simple.c
+++ b/test/simple.c
@@ -99,6 +99,7 @@ simpleCompress(elzma_file_format format, const unsigned char * inData,
             return rc;
         }
 
+        elzma_compress_free(&hand);
         *outData = ds.outData;
         *outLen = ds.outLen;
     }
@@ -132,7 +133,8 @@ simpleDecompress(elzma_file_format format, const unsigned char * inData,
             elzma_decompress_free(&hand);
             return rc;
         }
-        
+
+        elzma_decompress_free(&hand);
         *outData = ds.outData;
         *outLen = ds.outLen;
     }


### PR DESCRIPTION
Here's the valgrind output before the fix:

```
$ valgrind ./easylzma_test 
==17669== Memcheck, a memory error detector
==17669== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==17669== Using Valgrind-3.12.0 and LibVEX; rerun with -h for copyright info
==17669== Command: ./easylzma_test
==17669== 
round trip lzma test:    ok
round trip lzip test:    ok
correct lzip test:    ok
lzip as lzma test:    ok
correct lzma test:    ok
lzma as lzip test:    ok
corrupt crc test:    ok
bad lzip size test:    ok
bad lzma size test:    ok
bad lzma size 2 test:    ok

10/10 tests passed
==17669== 
==17669== HEAP SUMMARY:
==17669==     in use at exit: 27,790,268 bytes in 20 blocks
==17669==   total heap usage: 69 allocs, 49 frees, 79,406,342 bytes allocated
==17669== 
==17669== LEAK SUMMARY:
==17669==    definitely lost: 1,319,688 bytes in 8 blocks
==17669==    indirectly lost: 15,718,572 bytes in 11 blocks
==17669==      possibly lost: 10,752,008 bytes in 1 blocks
==17669==    still reachable: 0 bytes in 0 blocks
==17669==         suppressed: 0 bytes in 0 blocks
==17669== Rerun with --leak-check=full to see details of leaked memory
==17669== 
==17669== For counts of detected and suppressed errors, rerun with: -v
==17669== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
And here's the valgrind output after the fix:

```
$ valgrind ./easylzma_test
==19819== Memcheck, a memory error detector
==19819== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==19819== Using Valgrind-3.12.0 and LibVEX; rerun with -h for copyright info
==19819== Command: ./test/easylzma_test
==19819== 
round trip lzma test:    ok
round trip lzip test:    ok
correct lzip test:    ok
lzip as lzma test:    ok
correct lzma test:    ok
lzma as lzip test:    ok
corrupt crc test:    ok
bad lzip size test:    ok
bad lzma size test:    ok
bad lzma size 2 test:    ok

10/10 tests passed
==19819== 
==19819== HEAP SUMMARY:
==19819==     in use at exit: 0 bytes in 0 blocks
==19819==   total heap usage: 69 allocs, 69 frees, 79,406,342 bytes allocated
==19819== 
==19819== All heap blocks were freed -- no leaks are possible
==19819== 
==19819== For counts of detected and suppressed errors, rerun with: -v
==19819== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
